### PR TITLE
Render basic board tiles and spymaster view

### DIFF
--- a/frontend/frontend-app/package-lock.json
+++ b/frontend/frontend-app/package-lock.json
@@ -1316,6 +1316,25 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@popperjs/core": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.2.1.tgz",
+      "integrity": "sha512-BChdj3idQiLi+7vPhE6gEDiPzpozvSrUqbSMoSTlRbOQkU0p6u4si0UBydegTyphsYSZC2AUHGYYICP0gqmEVg=="
+    },
+    "@restart/context": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
+      "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q=="
+    },
+    "@restart/hooks": {
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.22.tgz",
+      "integrity": "sha512-tW0T3hP6emYNOc76/iC96rlu+f7JYLSVk/Wnn+7dj1gJUcw4CkQNLy16vx2mBLtVKsFMZ9miVEZXat8blruDHQ==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15"
+      }
+    },
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
@@ -2931,6 +2950,11 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
+    "bootstrap": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
+      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3358,6 +3382,11 @@
           }
         }
       }
+    },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "clean-css": {
       "version": "4.2.3",
@@ -4378,6 +4407,15 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "requires": {
         "utila": "~0.4"
+      }
+    },
+    "dom-helpers": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.4.tgz",
+      "integrity": "sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^2.6.7"
       }
     },
     "dom-serializer": {
@@ -8271,6 +8309,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash-es": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
+    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
@@ -10629,6 +10672,15 @@
         "react-is": "^16.8.1"
       }
     },
+    "prop-types-extra": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
+      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
+      "requires": {
+        "react-is": "^16.3.2",
+        "warning": "^4.0.0"
+      }
+    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -10799,6 +10851,26 @@
         "raf": "^3.4.1",
         "regenerator-runtime": "^0.13.3",
         "whatwg-fetch": "^3.0.0"
+      }
+    },
+    "react-bootstrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.0.0.tgz",
+      "integrity": "sha512-Ep6ZNH6wL5m9bytOS6T9mjSz0YE1bEkc+uHItvenRcA3amr5ApkpKYzAWgdglhRPZHPvm+pnqs1z5IPwv/2UZw==",
+      "requires": {
+        "@babel/runtime": "^7.4.2",
+        "@restart/context": "^2.1.4",
+        "@restart/hooks": "^0.3.21",
+        "@types/react": "^16.9.23",
+        "classnames": "^2.2.6",
+        "dom-helpers": "^5.1.2",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2",
+        "prop-types-extra": "^1.1.0",
+        "react-overlays": "^3.0.1",
+        "react-transition-group": "^4.0.0",
+        "uncontrollable": "^7.0.0",
+        "warning": "^4.0.3"
       }
     },
     "react-dev-utils": {
@@ -11060,6 +11132,25 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-overlays": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-3.0.1.tgz",
+      "integrity": "sha512-QEt6I3Cjy06pe2FwY/tuWaXEzSVOuXfP8zsC6oWHJhMYpEJQgZV/TCwbCw5slMW6VcgwcWPc4HrBzN0yfxf5Xw==",
+      "requires": {
+        "@babel/runtime": "^7.4.5",
+        "@popperjs/core": "^2.0.0",
+        "@restart/hooks": "^0.3.12",
+        "dom-helpers": "^5.1.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.0.0",
+        "warning": "^4.0.3"
+      }
+    },
     "react-router": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
@@ -11263,6 +11354,17 @@
             "read-pkg": "^2.0.0"
           }
         }
+      }
+    },
+    "react-transition-group": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.3.0.tgz",
+      "integrity": "sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
       }
     },
     "read-pkg": {
@@ -13233,6 +13335,17 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "uncontrollable": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.1.1.tgz",
+      "integrity": "sha512-EcPYhot3uWTS3w00R32R2+vS8Vr53tttrvMj/yA1uYRhf8hbTG2GyugGqWDY0qIskxn0uTTojVd6wPYW9ZEf8Q==",
+      "requires": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": "^16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
+      }
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -13522,6 +13635,14 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/frontend/frontend-app/package.json
+++ b/frontend/frontend-app/package.json
@@ -7,8 +7,10 @@
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
     "axios": "^0.19.2",
+    "bootstrap": "^4.4.1",
     "fetch": "^1.1.0",
     "react": "^16.13.1",
+    "react-bootstrap": "^1.0.0",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1"

--- a/frontend/frontend-app/src/App.js
+++ b/frontend/frontend-app/src/App.js
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter, Route } from "react-router-dom";
 import { Welcome } from "./Containers/Welcome";
 import { Game } from "./Containers/Game";
+import "bootstrap/dist/css/bootstrap.min.css";
 
 function App() {
   const drone = new window.Scaledrone(process.env.REACT_APP_SCALEDRONE);

--- a/frontend/frontend-app/src/Containers/Game/Game.css
+++ b/frontend/frontend-app/src/Containers/Game/Game.css
@@ -1,0 +1,40 @@
+.tile {
+  margin: 10px 0px;
+  text-align: center;
+}
+
+/* Tile types */
+.blue {
+  background-color: #bdcaff !important;
+}
+
+.red {
+  background-color: #ffa6a6 !important;
+}
+
+.neutral {
+    background-color: #fff9bd !important;
+}
+
+.death {
+  background-color: #000000 !important;
+  color: #ffffff !important;
+}
+
+.blue-spymaster {
+  color: #145ce0;
+  font-weight: bold;
+}
+
+.red-spymaster {
+  color: #e01414;
+  font-weight: bold;
+}
+
+.neutral-spymaster {
+
+}
+
+.death-spymaster {
+  background-color: #b5b5b5 !important;
+}

--- a/frontend/frontend-app/src/Containers/Game/Game.css
+++ b/frontend/frontend-app/src/Containers/Game/Game.css
@@ -4,29 +4,29 @@
 }
 
 /* Tile types */
-.blue {
+.blue-tile {
   background-color: #bdcaff !important;
 }
 
-.red {
+.red-tile {
   background-color: #ffa6a6 !important;
 }
 
-.neutral {
+.neutral-tile {
     background-color: #fff9bd !important;
 }
 
-.death {
+.death-tile {
   background-color: #000000 !important;
   color: #ffffff !important;
 }
 
-.blue-spymaster {
+.blue-bold {
   color: #145ce0;
   font-weight: bold;
 }
 
-.red-spymaster {
+.red-bold {
   color: #e01414;
   font-weight: bold;
 }

--- a/frontend/frontend-app/src/Containers/Game/Game.js
+++ b/frontend/frontend-app/src/Containers/Game/Game.js
@@ -1,0 +1,111 @@
+import React, { Component } from "react";
+import { Card, Col, Container, Row } from "react-bootstrap";
+import "./Game.css";
+
+/**
+ * Tile that displays a clue word. If previously clicked, will be styled to
+ * indicate the tile type (blue, red, death, or neutral).
+ */
+class Tile extends Component {
+  render() {
+    const { tile, idx, isSpymasterView, handleTileClick } = this.props;
+    const { clue, type, revealed } = tile;
+
+    let className = "";
+    if (revealed) {
+      className = type;
+    } else if (isSpymasterView) {
+      className = `${type}-spymaster`;
+    }
+
+    return (
+      <Col>
+        <Card
+          className={`tile ${className}`}
+          onClick={() => handleTileClick(revealed, isSpymasterView, idx)}
+        >
+          <Card.Body>{clue}</Card.Body>
+        </Card>
+      </Col>
+    );
+  }
+}
+
+/**
+ * Overall game board. Displays tiles with clues and control buttons.
+ */
+class Board extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isSpymasterView: false,
+    };
+  }
+
+  // When an eligible tile is clicked, sends a request to the server to get an
+  // updated board.
+  handleTileClick(revealed, isSpymasterView, idx) {
+    if (revealed || isSpymasterView) return;
+
+    // TODO(regina): Send move to server and retrieve updated board.
+    console.log(idx);
+  }
+
+  // Changes between player view (all plain tiles) and spymaster view (different
+  // tile types are shown).
+  toggleSpymasterView() {
+    this.setState((state) => {
+      return { ...state, isSpymasterView: !state.isSpymasterView };
+    });
+  }
+
+  renderTile(tile, idx) {
+    return (
+      <Tile
+        tile={tile}
+        idx={idx}
+        isSpymasterView={this.state.isSpymasterView}
+        handleTileClick={this.handleTileClick}
+        key={idx}
+      />
+    );
+  }
+
+  renderTiles() {
+    const { tiles } = this.props.game;
+    const MAX_TILES_PER_ROW = 5;
+
+    return (
+      <div>
+        <Container>
+          <Row md={MAX_TILES_PER_ROW} lg={MAX_TILES_PER_ROW}>
+            {tiles.map((tile, idx) => this.renderTile(tile, idx))}
+          </Row>
+        </Container>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <Container>
+        <div>{this.renderTiles()}</div>
+
+        <div className="custom-control custom-switch">
+          <input
+            type="checkbox"
+            className="custom-control-input"
+            id="spymasterViewSwitch"
+            checked={this.state.isSpymasterView}
+            onChange={() => this.toggleSpymasterView()}
+          />
+          <label className="custom-control-label" htmlFor="spymasterViewSwitch">
+            Spymaster View
+          </label>
+        </div>
+      </Container>
+    );
+  }
+}
+
+export default Board;

--- a/frontend/frontend-app/src/Containers/Game/Game.js
+++ b/frontend/frontend-app/src/Containers/Game/Game.js
@@ -1,5 +1,13 @@
 import React, { Component } from "react";
-import { Button, Card, Col, Container, Row } from "react-bootstrap";
+import {
+  Button,
+  ButtonGroup,
+  Card,
+  Col,
+  Container,
+  Dropdown,
+  Row,
+} from "react-bootstrap";
 import "./Game.css";
 
 /**
@@ -59,8 +67,7 @@ class Board extends Component {
       <Row>
         <Col>
           <div>
-            <span className="blue-bold">{numRemainingBlue}</span> -
-{" "}
+            <span className="blue-bold">{numRemainingBlue}</span> -{" "}
             <span className="red-bold">{numRemainingRed}</span>
           </div>
         </Col>
@@ -94,6 +101,59 @@ turn
     this.setState((state) => {
       return { ...state, isSpymasterView: !state.isSpymasterView };
     });
+  }
+
+  // When starting a new game, players have the option to choose clues from the
+  // default set of words or from their custom word bank (if available).
+  renderNewGameButton() {
+    return (
+      <Dropdown>
+        <Dropdown.Toggle variant="light" id="dropdown-basic">
+          New game
+        </Dropdown.Toggle>
+
+        <Dropdown.Menu>
+          <Dropdown.Item href="#/action-1">Default clues</Dropdown.Item>
+          <Dropdown.Item href="#/action-2">Custom clues</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
+    );
+  }
+
+  // Renders buttons to:
+  //    1. Toggle spymaster view
+  //    2. Start new game
+  //    3. Go to word bank management page
+  renderGameControls() {
+    return (
+      <Row>
+        <Col>
+          <div className="custom-control custom-switch">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="spymasterViewSwitch"
+              checked={this.state.isSpymasterView}
+              onChange={() => this.toggleSpymasterView()}
+            />
+            <label
+              className="custom-control-label"
+              htmlFor="spymasterViewSwitch"
+            >
+              Spymaster View
+            </label>
+          </div>
+        </Col>
+        <Col>
+          <div style={{ textAlign: "right" }}>
+            <ButtonGroup className="justify-content-between">
+              {this.renderNewGameButton()}{" "}
+              <Button variant="light">Edit word bank</Button>
+            </ButtonGroup>
+          </div>
+        </Col>
+      </Row>
+    );
   }
 
   // When an eligible tile is clicked, sends a request to the server to get an
@@ -139,18 +199,7 @@ turn
         {this.renderGameInfo(tiles, currentTurn)}
         {this.renderTiles(tiles)}
 
-        <div className="custom-control custom-switch">
-          <input
-            type="checkbox"
-            className="custom-control-input"
-            id="spymasterViewSwitch"
-            checked={this.state.isSpymasterView}
-            onChange={() => this.toggleSpymasterView()}
-          />
-          <label className="custom-control-label" htmlFor="spymasterViewSwitch">
-            Spymaster View
-          </label>
-        </div>
+        {this.renderGameControls()}
       </Container>
     );
   }

--- a/frontend/frontend-app/src/Containers/Game/Game.js
+++ b/frontend/frontend-app/src/Containers/Game/Game.js
@@ -15,21 +15,31 @@ import "./Game.css";
  * indicate the tile type (blue, red, death, or neutral).
  */
 class Tile extends Component {
+  getClassName(revealed, isSpymasterView, type) {
+    if (revealed) {
+      return type;
+    }
+    if (isSpymasterView) {
+      if (type === "death") {
+        return "death-spymaster";
+      }
+      return `${type}-bold`;
+    }
+    return "";
+  }
+
   render() {
     const { tile, idx, isSpymasterView, handleTileClick } = this.props;
     const { clue, type, revealed } = tile;
 
-    let className = "";
-    if (revealed) {
-      className = type;
-    } else if (isSpymasterView) {
-      className = `${type}-bold`;
-    }
-
     return (
       <Col>
         <Card
-          className={`tile ${className}`}
+          className={`tile ${this.getClassName(
+            revealed,
+            isSpymasterView,
+            type
+          )}`}
           onClick={() => handleTileClick(revealed, isSpymasterView, idx)}
         >
           <Card.Body>{clue}</Card.Body>

--- a/frontend/frontend-app/src/Containers/Game/Game.js
+++ b/frontend/frontend-app/src/Containers/Game/Game.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Card, Col, Container, Row } from "react-bootstrap";
+import { Button, Card, Col, Container, Row } from "react-bootstrap";
 import "./Game.css";
 
 /**
@@ -15,7 +15,7 @@ class Tile extends Component {
     if (revealed) {
       className = type;
     } else if (isSpymasterView) {
-      className = `${type}-spymaster`;
+      className = `${type}-bold`;
     }
 
     return (
@@ -42,13 +42,50 @@ class Board extends Component {
     };
   }
 
-  // When an eligible tile is clicked, sends a request to the server to get an
-  // updated board.
-  handleTileClick(revealed, isSpymasterView, idx) {
-    if (revealed || isSpymasterView) return;
+  endCurrentTurn() {
+    // TODO(regina): Send request to server to switch turns.
+    console.log("end current turn");
+  }
 
-    // TODO(regina): Send move to server and retrieve updated board.
-    console.log(idx);
+  renderGameInfo(tiles, currentTurn) {
+    const numRemainingBlue = tiles.filter(
+      (tile) => !tile.revealed && tile.type === "blue"
+    ).length;
+    const numRemainingRed = tiles.filter(
+      (tile) => !tile.revealed && tile.type === "red"
+    ).length;
+
+    return (
+      <Row>
+        <Col>
+          <div>
+            <span className="blue-bold">{numRemainingBlue}</span> -
+{" "}
+            <span className="red-bold">{numRemainingRed}</span>
+          </div>
+        </Col>
+
+        <Col>
+          <div
+            className={`${currentTurn}-bold`}
+            style={{ textAlign: "center" }}
+          >
+            {`${currentTurn}'s turn`}
+          </div>
+        </Col>
+
+        <Col>
+          <div style={{ textAlign: "right" }}>
+            <Button variant="light" onClick={() => this.endCurrentTurn()}>
+              End
+              {` ${currentTurn}'s `}
+{' '}
+turn
+</Button>
+          </div>
+        </Col>
+      </Row>
+    );
   }
 
   // Changes between player view (all plain tiles) and spymaster view (different
@@ -57,6 +94,15 @@ class Board extends Component {
     this.setState((state) => {
       return { ...state, isSpymasterView: !state.isSpymasterView };
     });
+  }
+
+  // When an eligible tile is clicked, sends a request to the server to get an
+  // updated board.
+  handleTileClick(revealed, isSpymasterView, idx) {
+    if (revealed || isSpymasterView) return;
+
+    // TODO(regina): Send move to server and retrieve updated board.
+    console.log(idx);
   }
 
   renderTile(tile, idx) {
@@ -71,8 +117,7 @@ class Board extends Component {
     );
   }
 
-  renderTiles() {
-    const { tiles } = this.props.game;
+  renderTiles(tiles) {
     const MAX_TILES_PER_ROW = 5;
 
     return (
@@ -87,9 +132,12 @@ class Board extends Component {
   }
 
   render() {
+    const { tiles, currentTurn } = this.props.game;
+
     return (
       <Container>
-        <div>{this.renderTiles()}</div>
+        {this.renderGameInfo(tiles, currentTurn)}
+        {this.renderTiles(tiles)}
 
         <div className="custom-control custom-switch">
           <input

--- a/frontend/frontend-app/src/Containers/Game/index.js
+++ b/frontend/frontend-app/src/Containers/Game/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import axios from "axios";
+import Board from "./Game";
 
 export const Game = ({ drone }) => {
   const { roomID } = useParams();
@@ -40,6 +41,8 @@ export const Game = ({ drone }) => {
     <div>
       <div>{`Room: ${roomID}`}</div>
       <div>{`Board State: ${JSON.stringify(gameState)}`}</div>
+
+      <Board game={gameState.game} />
     </div>
   );
 };


### PR DESCRIPTION
* Renders basic board using Bootstrap. At most, tiles are limited to 5 columns, but if the window gets narrower, number of columns will decrease so we won't have the traditional 5x5 board but that's fine for now.
* Clicking on a tile will just log its index currently; sending server request will be done later.
* Simple toggle button to switch between player and spymaster view.
* Renders other game controls (new game, edit word bank, end turn) but no actual functionality yet.

I see there'll be merge conflicts with your PR to refactor into game/word bank rooms but we'll deal with that depending on which PR is merged first.

**Player view:**
![Screenshot 2020-04-11 12 16 42](https://user-images.githubusercontent.com/17392448/79053055-354f2180-7bef-11ea-955c-e1ba38895775.png)

**Spymaster view:**
![Screenshot 2020-04-11 12 22 24](https://user-images.githubusercontent.com/17392448/79053042-28323280-7bef-11ea-97d9-9a343b6521ab.png)